### PR TITLE
Development/build: handle quote file excess blank line case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 fortune-vn
+fortune-vn.dat
 fortune-vn.data

--- a/bin/fortune.sh
+++ b/bin/fortune.sh
@@ -14,7 +14,7 @@ _fortune() {
   {
     for file in "${D_ROOT}"/data/*.txt; do
       cat "${file}"
-      if [[ $(tail -n 1 "${file}") != "%" ]]; then
+      if [[ $(grep . ${file} | tail -n 1) != "%" ]]; then
         echo %
       fi
     done


### PR DESCRIPTION
Okay, for example [this file](https://github.com/icy/fortune-vn/blob/master/data/taoquan.txt) have a blank line at the end. This make 
```tail -n 1 $file``` 
return
 ``` ``` 
just an empty line.

I think, better remove all blank line before check with:
```
grep . $file | tail -n 1
```
will handle that case.